### PR TITLE
Backlight on keypress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ emulation/linux-server-rootfs.jffs2
 
 # don't commit local modifications to the Renode filesystem template
 emulation/linux-server-rootfs.jffs2
+
+# bloat analyzer reports
+reports/

--- a/analyze-bloat.sh
+++ b/analyze-bloat.sh
@@ -47,7 +47,7 @@ mkdir -p reports/old
 # move just the files, not the directory
 find reports/ -maxdepth 1 -type f -name '[!.]*' -exec mv -n {} reports/old/ \;
 
-echo "===== TURNING OF STRIP ====="
+echo "===== TURNING OFF STRIP ====="
 sed -i 's/strip = true/strip = false/g' Cargo.toml
 
 echo "===== STARTING BUILD at $(date) ====="

--- a/analyze-bloat.sh
+++ b/analyze-bloat.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+declare -a Crates=(
+    "kernel"
+    "loader"
+    "gam"
+    "status"
+    "shellchat"
+    "ime-frontend"
+    "ime-plugin-shell"
+    "graphics-server"
+    "ticktimer-server"
+    "log-server"
+    "com"
+    "xous-names"
+    "keyboard"
+    "trng"
+    "llio"
+    "susres"
+    "codec"
+    "sha2"
+    "engine-25519"
+    "spinor"
+    "root-keys"
+    "jtag"
+    "net"
+    "dns"
+    "pddb"
+    "modals"
+    "usb-device-xous"
+    "vault"
+    "ball"
+    "repl"
+)
+
+if [ -e "$HOME/.cargo/env" ]; then
+    . "$HOME/.cargo/env"
+fi
+RISCV_TOOLS=/opt/riscv64-unknown-elf
+export PATH=$RISCV_TOOLS/bin:$PATH
+
+env | sort > env.txt
+
+#cargo clean
+mkdir -p reports
+mkdir -p reports/old
+# move just the files, not the directory
+find reports/ -maxdepth 1 -type f -name '[!.]*' -exec mv -n {} reports/old/ \;
+
+echo "===== TURNING OF STRIP ====="
+sed -i 's/strip = true/strip = false/g' Cargo.toml
+
+echo "===== STARTING BUILD at $(date) ====="
+cargo xtask app-image ball repl vault
+
+echo "===== ANALYZING at $(date) ====="
+for val in ${Crates[@]}; do
+    # dump the header summary
+    riscv64-unknown-elf-objdump -h target/riscv32imac-unknown-xous-elf/release/$val > reports/$val.txt
+    # dump the sorted list of objects
+    riscv64-unknown-elf-nm -r --size-sort --print-size target/riscv32imac-unknown-xous-elf/release/$val | rustfilt >> reports/$val.txt
+    # dump the disassembly
+    riscv64-unknown-elf-objdump -S -d target/riscv32imac-unknown-xous-elf/release/$val | rustfilt > reports/$val.list
+done
+
+
+echo "===== REVERTING STRIP ====="
+git checkout Cargo.toml

--- a/analyze-bloat.sh
+++ b/analyze-bloat.sh
@@ -45,7 +45,7 @@ env | sort > env.txt
 mkdir -p reports
 mkdir -p reports/old
 # move just the files, not the directory
-find reports/ -maxdepth 1 -type f -name '[!.]*' -exec mv -n {} reports/old/ \;
+find reports/ -maxdepth 1 -type f -name '[!.]*' -exec mv {} reports/old/ \;
 
 echo "===== TURNING OFF STRIP ====="
 sed -i 's/strip = true/strip = false/g' Cargo.toml

--- a/buildpush.ps1
+++ b/buildpush.ps1
@@ -3,7 +3,7 @@
 # set RUSTFLAGS=--remap-path-prefix=F:\largework\rust-win\code\xous-core\=build
 # $env:RUSTFLAGS="--remap-path-prefix=$(Get-Location)=build"
 
-cargo xtask app-image vault ball
+cargo xtask app-image vault
 # cargo xtask ffi-test
 # cargo xtask minimal precursors/soc.svd
 
@@ -23,3 +23,9 @@ scp -i c:/users/bunnie/.ssh/id_pi target/riscv32imac-unknown-xous-elf/release/xo
 # scp -i c:/users/bunnie/.ssh/id_pi target/riscv32imac-unknown-none-elf/release/xous.img target/riscv32imac-unknown-none-elf/release/loader.bin precursors/soc_csr.bin precursors/bbram-test1.nky pi@10.0.245.90:code/precursors/
 
 # wishbone-tool --load-name target/riscv32imac-unknown-none-elf/release/xous.img  --load-address 0x980000 --load-flash
+
+$file = Get-Item target/riscv32imac-unknown-xous-elf/release/xous.img
+$SizeinBytes = $file.Length
+if($SizeinBytes -gt 6815743) {
+    "Warning: xous.img exceeds the 24-bit limit of JTAG. Upload using USB instead!"
+}

--- a/services/keyboard/src/api.rs
+++ b/services/keyboard/src/api.rs
@@ -61,28 +61,28 @@ pub(crate) enum Opcode {
     RegisterRawListener = 3,
 
     /// request for updates for *when* keyboard is pressed
-    RegisterKeyObserver = 4,
+    RegisterKeyObserver = 12,
 
     /// set repeat delay, rate; both in ms
-    SetRepeat = 5, //(u32, u32),
+    SetRepeat = 4, //(u32, u32),
 
     /// set chording interval (how long to wait for all keydowns to happen before interpreting as a chord), in ms (for braille keyboards)
-    SetChordInterval = 6, //(u32),
+    SetChordInterval = 5, //(u32),
 
     /// used by host mode emulation and debug UART to inject keys
-    InjectKey = 7, //(char),
+    InjectKey = 6, //(char),
 
     /// used by the interrupt handler to transfer results to the main loop
-    HandlerTrigger = 8,
+    HandlerTrigger = 7,
 
     /// used to turn keyboard vibrate on and off
-    Vibe = 9,
+    Vibe = 8,
 
     /// a blocking key listener - blocks until a key is hit
-    BlockingKeyListener = 10,
+    BlockingKeyListener = 9,
 
     /// Suspend/resume callback
-    SuspendResume = 11,
+    SuspendResume = 10,
 }
 
 // this structure is used to register a keyboard listener. Currently, we only accept

--- a/services/keyboard/src/main.rs
+++ b/services/keyboard/src/main.rs
@@ -739,10 +739,9 @@ fn main() -> ! {
     //  - graphics (if building for hosted mode)
     //  - oqc (for factory test)
     //  - status sub system (for setting the layout)
-    //  - keyboard-backlight (to start backlight when a key is pressed)
     //  - USB (for getting layout)
     #[cfg(any(target_os = "none", target_os = "xous"))]
-    let kbd_sid = xns.register_name(api::SERVER_NAME_KBD, Some(6)).expect("can't register server");
+    let kbd_sid = xns.register_name(api::SERVER_NAME_KBD, Some(4)).expect("can't register server");
     #[cfg(not(any(target_os = "none", target_os = "xous")))]
     let kbd_sid = xns.register_name(api::SERVER_NAME_KBD, Some(5)).expect("can't register server");
     log::trace!("registered with NS -- {:?}", kbd_sid);


### PR DESCRIPTION
a couple changes I've picked up that need to be made so far, please see the commit comments for why they must be made.

I'm still doing a bit more testing, but one thing I'd want to do is also strip out the legacy backlight menu items entirely *before* this is merged because the menu order affects the CI scripts (they need to know how many times to press the down arrow to reach menu items like initializing root keys, so ideally, the number of menu items stays constant even if the contents change).